### PR TITLE
fix(tts): correct variable name in sayMessage function call

### DIFF
--- a/tts/tts.js
+++ b/tts/tts.js
@@ -295,7 +295,8 @@ const handleMessage = (obj) => {
         if(globalTTS && !checkPrivileges(data, globalTTSPrivileges)){
             return;
         }
-        sayMessage(textToSay.toLowerCase().trim(), userVoice, displayName);
+        // Use the selected voice (fieldData.voice) for global TTS
+        sayMessage(textToSay.toLowerCase().trim(), voice, displayName);
         return;
     }
 


### PR DESCRIPTION
The variable `userVoice` was incorrectly used in the `sayMessage` function call. It has been replaced with the correct variable `voice` to ensure the function works as intended.